### PR TITLE
Change SSM Parameter Store path to /iam/cis-publishers/

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ JSON.stringify(jwk);
 
 You can run the LDAP publisher locally to verify that it works. Make sure to set `DRY_RUN` if you want it to dry run.
 
-Make sure to run MAWS first, so you have access to the SSM parameters in `mozilla-iam`.
+Make sure to run [MAWS](https://github.com/mozilla-iam/mozilla-aws-cli) first, so you have access to the SSM parameters in `mozilla-iam`.
 
 ```bash
 $ PYTHONPATH="." serverless invoke local -f ldap --stage production
@@ -51,8 +51,8 @@ you have `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` set, you can read in a CIS 
 
 ```python
 >>> from cis_publishers.common import Profile
->>> april = Profile(email="apking@mozilla.com")
->>> april
+>>> jdoe = Profile(email="jdoe@mozilla.com")
+>>> jdoe
 {'access_information': {'access_provider': None, 'hris': {'egencia_pos_country': 'US', 'employee_id': '123456', 'managers_primary_work_email': '...'}
 ```
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -60,10 +60,12 @@ functions:
       OAUTH_CLIENT_ID: ${ssm:/iam/cis/${opt:stage, self:provider.stage}/ldap_publisher/client_id~true}
       OAUTH_CLIENT_SECRET: ${ssm:/iam/cis/${opt:stage, self:provider.stage}/ldap_publisher/client_secret~true}
       PUBLISHER_NAME: ldap
-      PUBLISHER_SIGNING_KEY: ${ssm:/iam/${opt:stage, self:provider.stage}/ldap_signing_key~true}
+      PUBLISHER_SIGNING_KEY: ${ssm:/iam/cis-publishers/${opt:stage, self:provider.stage}/ldap_signing_key~true}
     layers:
       - { Ref: PythonRequirementsLambdaLayer }
     description: Publish LDAP users to CIS
     maximumRetryAttempts: 0
     memorySize: 2048  # we see a corresponding decrease in runtime with increased RAM, so 2048 decreases runtime to ~45s
     timeout: 900
+resources:
+  Description: Mozilla IAM CIS publishers, including the LDAP publisher, which publish profiles into CIS

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
    name="cis_publishers",
-   version="1.0",
+   version="1.1.0",
    description="The various CIS publishers",
    author="April King",
    author_email="april@mozilla.com",


### PR DESCRIPTION
Previously the SSM Parameter Store parameters were stored in the root of /iam/ and not scoped to this product. This moves them into a scoped path. Once in a scoped path it will allow granular IAM permissions to Parameter Store parameters on a per product basis

I've made copies of the values in these new scoped locations, so all that needs to happen is to merge and deploy this code.

Once this is merged and deployed to dev/test/prod, cleanup by

- [ ] Deleting the no longer used SSM Parameter Store parameters `/iam/development/ldap_signing_key`, `/iam/production/ldap_signing_key` and `/iam/testing/ldap_signing_key`