### PR TITLE
Fetch null profile from CDN instead of GitHub and move unused code

### DIFF
--- a/cis_publishers/common/people.py
+++ b/cis_publishers/common/people.py
@@ -24,8 +24,8 @@ def __get_bearer_token():
     if BEARER_TOKEN is not None:
         return BEARER_TOKEN
 
-    if not environ.get("IAM_DISCOVERY_URL") or not environ.get("OIDC_DISCOVERY_URL"):
-        logging.error("IAM_DISCOVERY_URL or OIDC_DISCOVERY_URL not set")
+    if not environ.get("IAM_DISCOVERY_URL"):
+        logging.error("IAM_DISCOVERY_URL not set")
         raise EnvironmentError
 
     # First, we need to retrieve the discovery URL's contents
@@ -33,7 +33,8 @@ def __get_bearer_token():
     CHANGE_API_URL = discovery["api"]["endpoints"]["change"]
     OAUTH_AUDIENCE = discovery["api"]["audience"]
     PERSON_API_URL = discovery["api"]["endpoints"]["person"]
-    TOKEN_ENDPOINT = requests.get(environ["OIDC_DISCOVERY_URL"]).json()["token_endpoint"]
+    OIDC_DISCOVERY_URL = discovery["oidc_discovery_uri"]
+    TOKEN_ENDPOINT = requests.get(OIDC_DISCOVERY_URL).json()["token_endpoint"]
 
     # Then, we need to reach out to auth0 to get a bearer token
     BEARER_TOKEN = requests.post(TOKEN_ENDPOINT, json={

--- a/cis_publishers/common/unused_create_profile.py
+++ b/cis_publishers/common/unused_create_profile.py
@@ -1,0 +1,49 @@
+import logging
+import time
+from os import environ
+from cis_publishers.common import Profile
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler())
+
+def unused_create_profile(ldap_profile, pgp_public_keys, phone_numbers, email, ssh_public_keys, user_id):
+    """
+    Note that as it currently stands (2020-10-10), the LDAP publisher will only ever UPDATE a profile,
+    it will never CREATE one. The code in /cis_publishers/common/unused_create_profile remains in case
+    the decision ever changes, as it is known to work properly, and it fully documents what would be
+    done should the LDAP publisher ever create profiles.
+    """
+    prefix = environ["LDAP_USER_ID_PREFIX"]
+    p = Profile()
+
+    # This profile creation code is never used as the LDAP publisher does not create profiles
+    p.update({
+        "active": True,
+        "created": time.strftime("%Y-%m-%dT%H:%M:%S.000Z",
+                                 time.strptime(ldap_profile["created_at"], "%Y%m%d%H%M%SZ")),
+        "first_name": ldap_profile.get("first_name"),
+        "fun_title": ldap_profile.get("title", ""),  # workday title, if they have it
+        "last_name": ldap_profile.get("last_name"),
+        "last_modified": time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime()),
+        "pgp_public_keys": pgp_public_keys,
+        "phone_numbers": phone_numbers,
+        "primary_email": email,
+        "ssh_public_keys": ssh_public_keys,
+        "user_id": f"{prefix}|{user_id}",  # TODO: ONLY EVER USE PREFIX FOR EMPLOYEES, OTHERWISE QUERY AUTH0 FOR user_id INSTEAD
+        "usernames": {
+            "LDAP-posix_id": ldap_profile.get("posix", {}).get("uid"),
+            "LDAP-posix_uid": ldap_profile.get("posix", {}).get("uid_number"),
+            "LDAP-uuid": ldap_profile.get("entry_uuid"),
+        },
+    })
+
+    p["access_information"]["ldap"] = ldap_profile.get("groups")
+
+    p["identities"].update({
+        "mozilla_ldap_id": ldap_profile.get("distinguished_name"),
+        "mozilla_ldap_primary_email": email,
+        "mozilla_posix_id": ldap_profile.get("posix", {}).get("uid"),
+    })
+    # This profile creation code is never used as the LDAP publisher does not create profiles
+    logger.info(f"Creating user: {user_id} ({email})")

--- a/cis_publishers/ldap/handler.py
+++ b/cis_publishers/ldap/handler.py
@@ -67,7 +67,6 @@ def synchronize(email, ldap_profile):
 
     # convenience variables to make the code below cleaner
     display_level = "staff" if "o=com" in dn or "o=org" in dn else "private"
-    prefix = environ["LDAP_USER_ID_PREFIX"]
 
     # Update a profile
     try:
@@ -117,42 +116,10 @@ def synchronize(email, ldap_profile):
         #                          some future brainiac makes it all work
 
         # Note that as it currently stands (2020-10-10), the LDAP publisher will only ever UPDATE a profile,
-        # it will never CREATE one. This code remains in case the decision ever changes, as it is known to
-        # work properly, and it fully documents what would be done should the LDAP publisher ever create profiles.
-
-        return False  # noqa
-
-        p = Profile()
-
-        p.update({
-            "active": True,
-            "created": time.strftime("%Y-%m-%dT%H:%M:%S.000Z",
-                                     time.strptime(ldap_profile["created_at"], "%Y%m%d%H%M%SZ")),
-            "first_name": ldap_profile.get("first_name"),
-            "fun_title": ldap_profile.get("title", ""),  # workday title, if they have it
-            "last_name": ldap_profile.get("last_name"),
-            "last_modified": time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime()),
-            "pgp_public_keys": pgp_public_keys,
-            "phone_numbers": phone_numbers,
-            "primary_email": email,
-            "ssh_public_keys": ssh_public_keys,
-            "user_id": f"{prefix}|{user_id}",  # TODO: ONLY EVER USE PREFIX FOR EMPLOYEES, OTHERWISE QUERY AUTH0 FOR user_id INSTEAD
-            "usernames": {
-                "LDAP-posix_id": ldap_profile.get("posix", {}).get("uid"),
-                "LDAP-posix_uid": ldap_profile.get("posix", {}).get("uid_number"),
-                "LDAP-uuid": ldap_profile.get("entry_uuid"),
-            },
-        })
-
-        p["access_information"]["ldap"] = ldap_profile.get("groups")
-
-        p["identities"].update({
-            "mozilla_ldap_id": ldap_profile.get("distinguished_name"),
-            "mozilla_ldap_primary_email": email,
-            "mozilla_posix_id": ldap_profile.get("posix", {}).get("uid"),
-        })
-
-        logger.info(f"Creating user: {user_id} ({email})")
+        # it will never CREATE one. The code in /cis_publishers/common/unused_create_profile remains in case
+        # the decision ever changes, as it is known to work properly, and it fully documents what would be
+        # done should the LDAP publisher ever create profiles.
+        return False
 
     # Currently, only publish a changed profile
     p.publish(display_level=display_level)

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,13 +24,7 @@ provider:
   runtime: python3.8
   environment:
     IAM_DISCOVERY_URL: ${self:custom.IAM_DISCOVERY_URL.${opt:stage, self:provider.stage}}
-
-    # In theory, this should be discoverable via IAM_DISCOVERY_URL, but it's completely broken
-    # in development / testing, which just use the production endpoints anyways
-    OIDC_DISCOVERY_URL: https://auth.mozilla.com/.well-known/openid-configuration
-
-    # No idea why this isn't kept in the discovery URL
-    CIS_NULL_PROFILE_URL: https://raw.githubusercontent.com/mozilla-iam/cis/master/python-modules/cis_profile/cis_profile/data/user_profile_null.json
+    CIS_NULL_PROFILE_URL: https://auth.mozilla.com/.well-known/user_profile_null.json
   # TODO: Use serverless-iam-roles-per-function
   iamRoleStatements:
     - Effect: Allow


### PR DESCRIPTION
# Fetch null profile from CDN instead of GitHub

Change code to fetch the null profile from the auth.mozilla.com CDN instead of GitHub for robustness.
Also, remove the need to pass the OIDC Discovery URL in as it now works correctly through
the auth.mozilla.org proxy in dev and prod

# Remove the unused profile creation code into a dedicated file to prevent confusion

People (including me) repeatedly find the profile creation code and don't notice
in the page of code above the "return false" which causes the code to never be traversed.
This leads to confusion as readers think that the LDAP publisher creates ne profiles,
which it doesn't.

This moves the code into a names function that makes it clear it isn't used and adds
comments to point out that the code isn't used.

Fixes #3